### PR TITLE
Implement ComplianceGraph serialization

### DIFF
--- a/backend/src/wcp_backend/models/graph.py
+++ b/backend/src/wcp_backend/models/graph.py
@@ -7,7 +7,7 @@ Graph shape:
   WCP → Employee → Check → Verdict → TrustScore
 """
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 
@@ -60,5 +60,5 @@ class ComplianceGraph:
     trust_score: TrustScoreNode | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        # TODO: implement serialization for Phoenix/audit trace
-        raise NotImplementedError
+        """Serialize the graph to a dictionary for Phoenix/audit trace."""
+        return asdict(self)


### PR DESCRIPTION
I have implemented the `to_dict` method for the `ComplianceGraph` dataclass in `backend/src/wcp_backend/models/graph.py`.

The implementation uses `dataclasses.asdict(self)`, which is the standard Pythonic way to recursively convert dataclasses and their nested members into dictionaries. This fulfills the requirement for Phoenix/audit trace serialization.

I have verified the implementation using a standalone test script that covered all fields and nested nodes, including:
- WCPNode
- EmployeeNode
- CheckNode
- VerdictNode
- TrustScoreNode

The verification script confirmed that the `to_dict` method correctly produces a dictionary representation of the graph. I also performed a code review and recorded learnings related to the project's architecture and serialization patterns.

---
*PR created automatically by Jules for task [7697744888557477443](https://jules.google.com/task/7697744888557477443) started by @FishRaposo*