### PR TITLE
🧹 Implement serialization for ComplianceGraph

### DIFF
--- a/backend/src/wcp_backend/models/graph.py
+++ b/backend/src/wcp_backend/models/graph.py
@@ -7,7 +7,7 @@ Graph shape:
   WCP → Employee → Check → Verdict → TrustScore
 """
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 
@@ -60,5 +60,5 @@ class ComplianceGraph:
     trust_score: TrustScoreNode | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        # TODO: implement serialization for Phoenix/audit trace
-        raise NotImplementedError
+        """Serialize the graph for Phoenix/audit trace."""
+        return asdict(self)

--- a/backend/tests/unit/test_graph.py
+++ b/backend/tests/unit/test_graph.py
@@ -1,0 +1,41 @@
+import pytest
+from wcp_backend.models.graph import (
+    ComplianceGraph,
+    WCPNode,
+    EmployeeNode,
+    CheckNode,
+    VerdictNode,
+    TrustScoreNode,
+)
+
+def test_compliance_graph_to_dict():
+    wcp = WCPNode(
+        job_id="job_123",
+        contractor_name="Acme Corp",
+        project_name="Build-a-Bear",
+        week_ending="2023-10-27"
+    )
+    employees = [
+        EmployeeNode(name="John Doe", trade="Electrician", job_id="job_123")
+    ]
+    checks = [
+        CheckNode(check_id="check_1", check_type="wage", status="pass", employee_name="John Doe")
+    ]
+    verdict = VerdictNode(job_id="job_123", verdict="pass", confidence=0.95)
+    trust_score = TrustScoreNode(job_id="job_123", score=0.9, band="high", requires_review=False)
+
+    graph = ComplianceGraph(
+        wcp=wcp,
+        employees=employees,
+        checks=checks,
+        verdict=verdict,
+        trust_score=trust_score
+    )
+
+    result = graph.to_dict()
+
+    assert result["wcp"]["job_id"] == "job_123"
+    assert result["employees"][0]["name"] == "John Doe"
+    assert result["checks"][0]["check_id"] == "check_1"
+    assert result["verdict"]["verdict"] == "pass"
+    assert result["trust_score"]["score"] == 0.9


### PR DESCRIPTION
This PR implements the `to_dict` method in the `ComplianceGraph` class, which was previously a stub raising `NotImplementedError`. 

🎯 **What:** Implemented serialization for the compliance graph using the standard `dataclasses.asdict()` function.
💡 **Why:** Fulfills the requirement for Phoenix/audit trace serialization, improving the maintainability and observability of the codebase.
✅ **Verification:** Verified via a new unit test suite (`backend/tests/unit/test_graph.py`) and a standalone verification script confirming correct nested dictionary output.
✨ **Result:** The `ComplianceGraph` can now be easily serialized for logging, auditing, and tracing purposes.

---
*PR created automatically by Jules for task [6068200468960984678](https://jules.google.com/task/6068200468960984678) started by @FishRaposo*