### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent fail-open security configurations in production

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - [Fail-Open Production Configuration Guardrails]
+**Vulnerability:** The Node.js agent backend defined default security configurations (`JWT_SECRET="change-me-before-launch"`, `AUTH_DISABLED="false"`) that were not explicitly validated upon startup when the service environment transitions to `production`. A developer or automated CD pipeline that fails to inject correct production secrets could inadvertently deploy an application vulnerable to complete token forgery and authorization bypass.
+**Learning:** Hardcoded defaults for critical authentication logic—even as development fallbacks—introduce significant risk if validation checks are missing during production deployments.
+**Prevention:** Always enforce strict guardrails for required secrets. If an application must gracefully boot with dev-only defaults in local environments, explicitly throw initialization errors if those same default secrets are observed while `NODE_ENV === "production"`.

--- a/agent/src/config.ts
+++ b/agent/src/config.ts
@@ -33,6 +33,21 @@ if (raw.NODE_ENV === "production" && raw.LLM_MODE === "mock") {
   );
 }
 
+// Security validations for production environments
+if (raw.NODE_ENV === "production") {
+  if (raw.JWT_SECRET === "change-me-before-launch") {
+    throw new Error(
+      "CRITICAL: Default JWT_SECRET is not allowed in production. Set a strong, unique secret to prevent token forgery."
+    );
+  }
+
+  if (raw.AUTH_DISABLED === "true") {
+    throw new Error(
+      "CRITICAL: AUTH_DISABLED=true is not allowed in production. Authentication must be enforced."
+    );
+  }
+}
+
 export const config = raw;
 export type Config = typeof config;
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Prevent fail-open security configurations in production

🚨 Severity: CRITICAL
💡 Vulnerability: Hardcoded defaults for JWT_SECRET and AUTH_DISABLED logic were able to be launched without failing the service initialization sequence. 
🎯 Impact: Complete bypass of authentication allowing remote attackers to forge signed tokens natively if service goes into production lacking environment bindings.
🔧 Fix: Added validation to `agent/src/config.ts` enforcing strict exceptions if default secrets are detected while `NODE_ENV === "production"`.
✅ Verification: `npm run typecheck`, `npm run lint` and `npm run test` have been successfully verified inside the node container locally to make sure regressions aren't produced.

---
*PR created automatically by Jules for task [13548120871734829783](https://jules.google.com/task/13548120871734829783) started by @FishRaposo*