### PR TITLE
⚡ Bolt: Optimize analytics dashboard aggregations with useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Avoid Unnecessary Recalculation on Re-renders with useMemo
+**Learning:** React components that calculate aggregate data (e.g. dashboards) often compute expensive operations such as `.reduce()` and `.map()` on the component render. These can significantly impact performance, especially when handling analytics data arrays.
+**Action:** When calculating derived aggregate states (like `totalDecisions`, averages, sums, etc.) from props or fetched arrays, always wrap them in `useMemo` hooks with proper dependency arrays to prevent recalculating them on every re-render.

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useDecisionStream } from "../hooks/useDecisionStream.ts";
 import { useDecisions } from "../hooks/useDecisions.ts";
 import { useApprovalByTrade } from "../hooks/useAnalytics.ts";
@@ -13,10 +14,11 @@ export default function Dashboard() {
   const totalDecisions = approvalData?.overall.total ?? 0;
   const approvalRate = approvalData?.overall.rate ?? 0;
 
-  const avgTrust =
-    recentDecisions && recentDecisions.length > 0
+  const avgTrust = useMemo(() => {
+    return recentDecisions && recentDecisions.length > 0
       ? recentDecisions.reduce((sum, d) => sum + d.trust_score, 0) / recentDecisions.length
       : 0;
+  }, [recentDecisions]);
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/Login.test.tsx
+++ b/frontend/src/pages/Login.test.tsx
@@ -39,10 +39,13 @@ describe("Login page", () => {
     await user.type(screen.getByPlaceholderText(/••••••••/), "password");
     await user.click(screen.getByRole("button", { name: /sign in/i }));
 
-    const calls = setItemSpy.mock.calls;
-    const tokenCall = calls.find((c) => c[0] === "wcp_token");
-    expect(tokenCall).toBeDefined();
-    expect(tokenCall![1]).toBe("mock-jwt-token");
+    // Wait for the async API call to complete by waiting for the localStorage call
+    await vi.waitFor(() => {
+      const calls = setItemSpy.mock.calls;
+      const tokenCall = calls.find((c) => c[0] === "wcp_token");
+      expect(tokenCall).toBeDefined();
+      expect(tokenCall![1]).toBe("mock-jwt-token");
+    });
 
     setItemSpy.mockRestore();
   });

--- a/frontend/src/pages/analytics/compliance.tsx
+++ b/frontend/src/pages/analytics/compliance.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { KPICard } from "@/components/analytics/KPICard";
 import { AnalyticsLayout } from "@/components/analytics/AnalyticsLayout";
@@ -21,17 +21,20 @@ export default function AnalyticsCompliance() {
     queryKey: ["analytics", "v4", "compliance", period],
     queryFn: () => apiClient.get(`/api/analytics/compliance`, { period }),
   });
-  const totalDecisions =
-    summary?.by_locality.reduce((total, locality) => total + locality.total, 0) ??
-    summary?.by_trade.reduce((total, trade) => total + trade.total, 0) ??
-    0;
-  const approvalRate =
-    summary?.by_locality.length && totalDecisions > 0
+  const totalDecisions = useMemo(() => {
+    return summary?.by_locality.reduce((total, locality) => total + locality.total, 0) ??
+      summary?.by_trade.reduce((total, trade) => total + trade.total, 0) ??
+      0;
+  }, [summary]);
+
+  const approvalRate = useMemo(() => {
+    return summary?.by_locality.length && totalDecisions > 0
       ? summary.by_locality.reduce(
           (weighted, locality) => weighted + locality.approval_rate * locality.total,
           0
         ) / totalDecisions
       : 0;
+  }, [summary, totalDecisions]);
 
   return (
     <AnalyticsLayout

--- a/frontend/src/pages/analytics/llm.tsx
+++ b/frontend/src/pages/analytics/llm.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { KPICard } from "@/components/analytics/KPICard";
 import { AnalyticsLayout } from "@/components/analytics/AnalyticsLayout";
@@ -46,7 +46,7 @@ export default function AnalyticsLLM() {
     queryFn: () => apiClient.get(`/api/analytics/llm`, { period }),
   });
 
-  const summary: LLMSummary = {
+  const summary: LLMSummary = useMemo(() => ({
     total_cost: analytics?.cost_per_decision.reduce((total, point) => total + point.total_cost, 0) ?? 0,
     cost_per_decision:
       analytics?.cost_per_decision.length
@@ -60,7 +60,7 @@ export default function AnalyticsLLM() {
         : 0,
     total_tokens: analytics?.token_usage.reduce((total, point) => total + point.total_tokens, 0) ?? 0,
     decisions: analytics?.cost_per_decision.reduce((total, point) => total + point.decisions, 0) ?? 0,
-  };
+  }), [analytics]);
 
   return (
     <AnalyticsLayout

--- a/frontend/src/pages/analytics/wages.tsx
+++ b/frontend/src/pages/analytics/wages.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { KPICard } from "@/components/analytics/KPICard";
 import { AnalyticsLayout } from "@/components/analytics/AnalyticsLayout";
@@ -36,26 +36,41 @@ export default function AnalyticsWages() {
     queryKey: ["analytics", "v4", "wages", period],
     queryFn: () => apiClient.get(`/api/analytics/wages`, { period }),
   });
-  const totalChecked = summary?.violation_trend.reduce((total, point) => total + point.total_checked, 0) ?? 0;
-  const totalViolations = summary?.violation_trend.reduce((total, point) => total + point.violations, 0) ?? 0;
-  const violationRate = totalChecked > 0 ? (totalViolations / totalChecked) * 100 : 0;
-  const actualVsRequired = summary?.actual_vs_required.map((point) => ({
-    ...point,
-    required: "required" in point ? point.required : point.required_wage,
-    total: "total" in point && point.total !== undefined ? point.total : 1,
-  }));
-  const avgWageDelta =
-    actualVsRequired?.length
+  const totalChecked = useMemo(() => {
+    return summary?.violation_trend.reduce((total, point) => total + point.total_checked, 0) ?? 0;
+  }, [summary]);
+
+  const totalViolations = useMemo(() => {
+    return summary?.violation_trend.reduce((total, point) => total + point.violations, 0) ?? 0;
+  }, [summary]);
+
+  const violationRate = useMemo(() => {
+    return totalChecked > 0 ? (totalViolations / totalChecked) * 100 : 0;
+  }, [totalChecked, totalViolations]);
+
+  const actualVsRequired = useMemo(() => {
+    return summary?.actual_vs_required.map((point) => ({
+      ...point,
+      required: "required" in point ? point.required : point.required_wage,
+      total: "total" in point && point.total !== undefined ? point.total : 1,
+    }));
+  }, [summary]);
+
+  const avgWageDelta = useMemo(() => {
+    return actualVsRequired?.length
       ? actualVsRequired.reduce(
           (total, point) => total + (point.actual_avg - point.required),
           0
         ) / actualVsRequired.length
       : 0;
-  const fringeCompliance =
-    summary?.fringe_compliance.length
+  }, [actualVsRequired]);
+
+  const fringeCompliance = useMemo(() => {
+    return summary?.fringe_compliance.length
       ? summary.fringe_compliance.reduce((total, point) => total + point.compliant_pct, 0) /
         summary.fringe_compliance.length
       : 0;
+  }, [summary]);
 
   return (
     <AnalyticsLayout


### PR DESCRIPTION
💡 What: Added `useMemo` hooks to cache the results of expensive array calculations (like sums and averages via `.reduce()` and `.map()`) in the dashboard and analytics pages (`Dashboard.tsx`, `compliance.tsx`, `wages.tsx`, `llm.tsx`). Also fixed a flaky test in `Login.test.tsx`.

🎯 Why: These analytics components were recalculating totals and averages over potentially large arrays of data points on every single component re-render. Since these values are strictly derived from fetched data, they only need to be recomputed when the underlying data changes, not on unrelated UI updates.

📊 Impact: Reduces CPU time spent on data transformation and prevents unnecessary recalculations, leading to smoother UI updates, especially when interacting with filters or hovering over charts that might trigger re-renders.

🔬 Measurement: Verified functionality using `npm run typecheck` and `npm run test`. The reduction in recalculations can be measured by profiling the React components before and after the change while interacting with the page.

---
*PR created automatically by Jules for task [9726903984634010037](https://jules.google.com/task/9726903984634010037) started by @FishRaposo*